### PR TITLE
refactor: simplify textarea props

### DIFF
--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -2,10 +2,10 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
-
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(
   ({ className, ...props }, ref) => {
     return (
       <textarea


### PR DESCRIPTION
## Summary
- refactor Textarea component to use `React.TextareaHTMLAttributes<HTMLTextAreaElement>` directly

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 18 problems including `@typescript-eslint/no-explicit-any`)


------
https://chatgpt.com/codex/tasks/task_e_6897221a86fc833282c540993698d0dd