### PR TITLE
refactor: narrow error type in AddPlayer

### DIFF
--- a/frontend/src/pages/AddPlayer.tsx
+++ b/frontend/src/pages/AddPlayer.tsx
@@ -33,8 +33,12 @@ const AddPlayer = () => {
       });
 
       navigate(`/game/${gameId}`);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError(String(err));
+      }
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- narrow `catch` clause to `unknown`
- display message from `Error` objects or stringified fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 18 problems (11 errors, 7 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6897221f23d48332b4d3135a1a3f5bb1