### PR TITLE
Use unknown for error handling in AllGames page

### DIFF
--- a/frontend/src/pages/AllGames.tsx
+++ b/frontend/src/pages/AllGames.tsx
@@ -17,8 +17,8 @@ const AllGames = () => {
       try {
         const res = await getGames();
         setGames(res.data);
-      } catch (err: any) {
-        setError(err.message);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : String(err));
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- handle `getGames` request errors using `unknown` and safe type checks

## Testing
- `npm run lint` *(fails: 18 problems, 11 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6897222364748332a69fd5914114402f