### PR TITLE
refactor: use unknown error type in CreateGame

### DIFF
--- a/frontend/src/pages/CreateGame.tsx
+++ b/frontend/src/pages/CreateGame.tsx
@@ -24,8 +24,9 @@ const CreateGame = () => {
 
       // Navigate to the new game's session page
       navigate(`/game/${game.id}`);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      setError(errorMessage);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- handle CreateGame errors using `unknown` and convert them to strings before display

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: pre-existing lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_6897224731308332918f6b7ab4e0a5d8