### PR TITLE
Refine error handling in GameSession

### DIFF
--- a/frontend/src/pages/GameSession.tsx
+++ b/frontend/src/pages/GameSession.tsx
@@ -34,8 +34,12 @@ const GameSession = () => {
         ]);
         setPlayers(gameRes.data.players);
         setLogs(logsRes.data);
-      } catch (err: any) {
-        setError(err.message);
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError("An unknown error occurred");
+        }
       } finally {
         setLoading(false);
       }
@@ -116,8 +120,9 @@ const GameSession = () => {
       });
       const logsRes = await getLogsByGame(gameId!);
       setLogs(logsRes.data);
-    } catch (err: any) {
-      toast({ title: "Error", description: err.message, variant: "destructive" });
+    } catch (err: unknown) {
+      const description = err instanceof Error ? err.message : "An unknown error occurred";
+      toast({ title: "Error", description, variant: "destructive" });
     } finally {
       setSelectedPlayer(null);
       setSelectedTargets([]);
@@ -139,8 +144,9 @@ const GameSession = () => {
     try {
       await completeGame(gameId!, winner);
       toast({ title: "Game Completed", description: `Winner: ${winner}` });
-    } catch (err: any) {
-      toast({ title: "Error", description: err.message, variant: "destructive" });
+    } catch (err: unknown) {
+      const description = err instanceof Error ? err.message : "An unknown error occurred";
+      toast({ title: "Error", description, variant: "destructive" });
     }
   };
 


### PR DESCRIPTION
## Summary
- Guard against non-Error values when loading game session
- Safely report errors when executing actions and ending the game

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, react-refresh/only-export-components, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6897224b65908332b53f64c6d9435108