### PR TITLE
Handle unknown errors in Results page

### DIFF
--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -49,8 +49,9 @@ const Results = () => {
 
           setGames(completed);
         }
-      } catch (err: any) {
-        setError(err.message || "Failed to load results");
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message || "Failed to load results");
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- use `unknown` type for caught errors in results page and safely derive message

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type and others)*

------
https://chatgpt.com/codex/tasks/task_e_6897224f38188332bc591e75009bb6af