### PR TITLE
feat: use ESM import for tailwind animate plugin

### DIFF
--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+	plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- refactor tailwind config to use ESM import for tailwindcss-animate plugin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 18 problems (11 errors, 7 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68972252a9ac83329827130989d3cc2c